### PR TITLE
switch from an hardcoded html filter, to a multimatch pattern filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Should also work in similar fashion with the `metalsmith.json` counterpart.
 
 `wordcount` accepts an hash to provide a few customization options.
 
+### `pattern` (optional)
+`String`: Only files that match this pattern will be processed.
+default: `*`
+
 ### `metaKeyCount` (optional)
 `String`: Name of the key that will store the word count in a file's metadata.  
 default: `wordCount`
@@ -58,6 +62,7 @@ default: `false`
 Metalsmith(__dirname)
   // html files are available (e.g. state when markdown was compiled)
   .use(wordcount({
+    pattern: "**/*.md",
     metaKeyCount: "wordCount",
     metaKeyReadingTime: "readingTime",
     speed: 300,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "chai": "~1.8.0",
-    "metalsmith": "^1.0.1"
+    "metalsmith": "^1.0.1",
+    "multimatch": "^2.1.0"
   }
 }


### PR DESCRIPTION
The plugin didn't worked for my metalsmith setup, because there is an hardcoded filter for html files, while I use md files.
As I use layouts as well, the html files result from a templating process, hence are non modifiable.

Instead, I used multimatch to remove the hardcoded filter with an optional filter.